### PR TITLE
feat(form): add quick deadline panel, clear completed and layout polish

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,11 +22,6 @@
       <span class="logo-icon">✅</span>
       <span class="logo-text">To-Do Planner</span>
     </div>
-    <nav class="header-nav">
-      <a href="#quote-section">Quote</a>
-      <a href="#task-form-section">Tasks</a>
-      <a href="#stats-section">Stats</a>
-    </nav>
     <button id="theme-toggle" onclick="toggleTheme()">🌙 Dark</button>
   </header>
 
@@ -56,27 +51,40 @@
           <option value="normal">🟡 Normal</option>
           <option value="relaxed">🟢 Relaxed</option>
         </select>
-        <input type="date" id="task-deadline" />
+        <button type="button" id="deadline-toggle" onclick="toggleDeadlinePanel()">📅 <span
+            id="deadline-display">fără</span></button>
+        <div class="deadline-panel" id="deadline-panel">
+          <div class="quick-deadlines">
+            <button type="button" onclick="setQuickDeadline('none')">🚫 Fără</button>
+            <button type="button" onclick="setQuickDeadline('today')">📅 Astăzi</button>
+            <button type="button" onclick="setQuickDeadline('week')">📆 Săptămâna asta</button>
+            <button type="button" onclick="setQuickDeadline('month')">🗓️ Luna asta</button>
+          </div>
+          <input type="date" id="task-deadline" onchange="onDeadlineChange()" />
+        </div>
         <button id="add-task-btn" onclick="addTask()">Adaugă</button>
       </div>
     </section>
 
     <!-- ===== TASK LIST ===== -->
-    <div class="task-list-header">
-      <h2>📋 Lista de taskuri</h2>
-      <select id="filter-category" onchange="filterTasks()">
-        <option value="all">Toate</option>
-        <option value="school">🎓 Școală</option>
-        <option value="personal">👤 Personal</option>
-        <option value="project">💼 Proiect</option>
-      </select>
-      <select id="sort-tasks" onchange="filterTasks()">
-        <option value="created">⏱️ Adăugare</option>
-        <option value="deadline">📅 Deadline</option>
-        <option value="priority">🔥 Prioritate</option>
-      </select>
-    </div>
-
+    <section id="task-list-section">
+      <div class="task-list-header">
+        <h2>📋 Taskurile mele</h2>
+        <select id="filter-category" onchange="filterTasks()">
+          <option value="all">🌐 Toate</option>
+          <option value="school">🎓 Școală</option>
+          <option value="personal">👤 Personal</option>
+          <option value="project">💼 Proiect</option>
+        </select>
+        <select id="sort-tasks" onchange="filterTasks()">
+          <option value="created">⏱️ Adăugare</option>
+          <option value="deadline">📅 Deadline</option>
+          <option value="priority">🔥 Prioritate</option>
+        </select>
+        <button id="clear-completed-btn" onclick="clearCompleted()">🧹 Șterge completate</button>
+      </div>
+      <ul id="task-list"></ul>
+    </section>
 
     <!-- ===== STATISTICS ===== -->
     <section id="stats-section">

--- a/script.js
+++ b/script.js
@@ -27,19 +27,162 @@ function updateStats() {
     document.getElementById('completed-tasks').textContent = completed;
     document.getElementById('pending-tasks').textContent = total - completed;
     const pct = total ? Math.round((completed / total) * 100) : 0;
-    document.getElementById('progress-fill').style.width = pct + '%';
-    document.getElementById('progress-label').textContent = pct + '% completate';
+    const fill = document.getElementById('progress-fill');
+    const label = document.getElementById('progress-label');
+    if (fill) fill.style.width = pct + '%';
+    if (label) label.textContent = pct + '% completate';
 }
 
+// ===== RENDER TASKS =====
+function renderTasks(filter = 'all') {
+    const list = document.getElementById('task-list');
+    let filtered = filter === 'all' ? [...tasks] : tasks.filter(t => t.category === filter);
+
+    const sortEl = document.getElementById('sort-tasks');
+    const sort = sortEl ? sortEl.value : 'created';
+    const prioRank = { urgent: 0, normal: 1, relaxed: 2 };
+    if (sort === 'deadline') {
+        filtered.sort((a, b) => (a.deadline || '9999-12-31').localeCompare(b.deadline || '9999-12-31'));
+    } else if (sort === 'priority') {
+        filtered.sort((a, b) => prioRank[a.priority] - prioRank[b.priority]);
+    } else {
+        filtered.sort((a, b) => a.id - b.id);
+    }
+
+    const today = new Date().toISOString().split('T')[0];
+    const urgencyLabel = (t) => {
+        if (!t.deadline) return '';
+        if (t.deadline < today) return '🔥 Expirat';
+        const diff = Math.ceil((new Date(t.deadline) - new Date(today)) / 86400000);
+        if (diff === 0) return '🔥 Astăzi';
+        if (diff === 1) return '⏰ Mâine';
+        if (diff <= 3) return `⚡ ${diff} zile`;
+        return `🕒 ${diff} zile`;
+    };
+
+    if (filtered.length === 0) {
+        list.innerHTML = '<p class="no-tasks">Nu ai taskuri momentan.</p>';
+        return;
+    }
+
+    const priorityLabels = { urgent: '🔴 Urgent', normal: '🟡 Normal', relaxed: '🟢 Relaxed' };
+    const categoryLabels = { school: '🎓 Școală', personal: '👤 Personal', project: '💼 Proiect' };
+
+    list.innerHTML = filtered.map(t => {
+        const overdue = t.deadline && t.deadline < today && !t.completed;
+        return `
+        <div class="task-item ${t.completed ? 'completed' : ''} ${overdue ? 'overdue' : ''}" data-priority="${t.priority}" data-id="${t.id}">
+            <div class="task-info">
+                <input type="checkbox" ${t.completed ? 'checked' : ''} onchange="toggleTask(${t.id})" />
+                <span class="task-text">${overdue ? '⚠️ ' : ''}${t.text}</span>
+            </div>
+            <div class="task-meta">
+                ${t.deadline ? `<span class="task-badge deadline">📅 ${t.deadline}</span>` : ''}
+                ${t.deadline && !t.completed ? `<span class="task-badge urgency u-${t.deadline < today ? 'over' : ''}">${urgencyLabel(t)}</span>` : ''}
+                <span class="task-badge category">${categoryLabels[t.category]}</span>
+                <span class="task-badge priority">${priorityLabels[t.priority]}</span>
+                <button class="edit-btn" onclick="editTask(${t.id})">✏️</button>
+                <button class="delete-btn" onclick="deleteTask(${t.id})">🗑️</button>
+            </div>
+        </div>
+    `;
+    }).join('');
+
+    requestAnimationFrame(() => {
+        list.querySelectorAll('.task-item').forEach(el => el.classList.add('show'));
+    });
+}
+
+// ===== QUICK DEADLINE =====
+function toggleDeadlinePanel() {
+    document.getElementById('deadline-panel').classList.toggle('open');
+}
+
+function quickDateFor(type) {
+    if (type === 'none') return '';
+    const d = new Date();
+    if (type === 'today') return d.toISOString().split('T')[0];
+    if (type === 'week') {
+        const day = d.getDay() || 7;
+        d.setDate(d.getDate() + (7 - day));
+    } else if (type === 'month') {
+        d.setMonth(d.getMonth() + 1, 0);
+    }
+    return d.toISOString().split('T')[0];
+}
+
+function syncQuickButtons() {
+    const v = document.getElementById('task-deadline').value;
+    const map = { none: quickDateFor('none'), today: quickDateFor('today'), week: quickDateFor('week'), month: quickDateFor('month') };
+    const types = ['none', 'today', 'week', 'month'];
+    document.querySelectorAll('.quick-deadlines button').forEach((b, i) => {
+        b.classList.toggle('active', map[types[i]] === v);
+    });
+}
+
+function onDeadlineChange() {
+    const v = document.getElementById('task-deadline').value;
+    document.getElementById('deadline-display').textContent = v || 'fără';
+    syncQuickButtons();
+}
+
+function setQuickDeadline(type) {
+    const input = document.getElementById('task-deadline');
+    input.value = quickDateFor(type);
+    document.getElementById('deadline-display').textContent = input.value || 'fără';
+    syncQuickButtons();
+}
+
+// ===== CLEAR COMPLETED =====
+function clearCompleted() {
+    const completed = tasks.filter(t => t.completed);
+    if (completed.length === 0) return;
+    if (!confirm(`Ștergi ${completed.length} task(uri) completate?`)) return;
+    document.querySelectorAll('.task-item.completed').forEach(el => el.classList.add('removing'));
+    setTimeout(() => {
+        tasks = tasks.filter(t => !t.completed);
+        saveTasks();
+        renderTasks(document.getElementById('filter-category').value);
+        updateStats();
+    }, 350);
+}
+
+// ===== EDIT TASK =====
+function editTask(id) {
+    const task = tasks.find(t => t.id === id);
+    if (!task) return;
+    const newText = prompt('Editează taskul:', task.text);
+    if (newText === null || newText.trim() === '') return;
+    task.text = newText.trim();
+    saveTasks();
+    renderTasks(document.getElementById('filter-category').value);
+}
+
+// ===== DELETE TASK =====
+function deleteTask(id) {
+    if (!confirm('Ești sigur că vrei să ștergi acest task?')) return;
+    const el = document.querySelector(`.task-item[data-id="${id}"]`);
+    if (el) el.classList.add('removing');
+    setTimeout(() => {
+        tasks = tasks.filter(t => t.id !== id);
+        saveTasks();
+        renderTasks(document.getElementById('filter-category').value);
+        updateStats();
+    }, 350);
+}
 
 // ===== INIT =====
 window.onload = function () {
     const savedTheme = localStorage.getItem('theme') || 'light';
     document.documentElement.setAttribute('data-theme', savedTheme);
     document.getElementById('theme-toggle').textContent = savedTheme === 'dark' ? '☀️ Light' : '🌙 Dark';
-    fetchQuote();
-    renderTasks();
     updateStats();
+    renderTasks();
+    fetchQuote();
+
+    document.getElementById('task-input').addEventListener('keydown', function (e) {
+        if (e.key === 'Enter') addTask();
+    });
 }
 
 // ===== FETCH QUOTE =====
@@ -74,6 +217,9 @@ function addTask() {
     saveTasks();
     input.value = '';
     document.getElementById('task-deadline').value = '';
+    document.querySelectorAll('.quick-deadlines button').forEach(b => b.classList.remove('active'));
+    document.getElementById('deadline-display').textContent = 'fără';
+    document.getElementById('deadline-panel').classList.remove('open');
     renderTasks(document.getElementById('filter-category').value);
     updateStats();
 }
@@ -90,75 +236,4 @@ function toggleTask(id) {
 function filterTasks() {
     const filter = document.getElementById('filter-category').value;
     renderTasks(filter);
-}
-
-// ===== RENDER TASKS =====
-function renderTasks(filter = 'all') {
-    const list = document.getElementById('task-list');
-    let filtered = filter === 'all' ? [...tasks] : tasks.filter(t => t.category === filter);
-
-    const sortEl = document.getElementById('sort-tasks');
-    const sort = sortEl ? sortEl.value : 'created';
-    const prioRank = { urgent: 0, normal: 1, relaxed: 2 };
-    if (sort === 'deadline') {
-        filtered.sort((a, b) => (a.deadline  '9999-12-31').localeCompare(b.deadline  '9999-12-31'));
-    } else if (sort === 'priority') {
-        filtered.sort((a, b) => prioRank[a.priority] - prioRank[b.priority]);
-    } else {
-        filtered.sort((a, b) => a.id - b.id);
-    }
-
-    const today = new Date().toISOString().split('T')[0];
-    const urgencyLabel = (t) => {
-        if (!t.deadline) return '';
-        if (t.deadline < today) return '🔥 Expirat';
-        const diff = Math.ceil((new Date(t.deadline) - new Date(today)) / 86400000);
-        if (diff === 0) return '🔥 Astăzi';
-        if (diff === 1) return '⏰ Mâine';
-        if (diff <= 3) return ⚡ ${diff} zile;
-        return 🕒 ${diff} zile;
-    };
-
-    if (filtered.length === 0) {
-        list.innerHTML = '<p class="no-tasks">Nu ai taskuri momentan.</p>';
-        return;
-    }
-
-    const priorityLabels = { urgent: '🔴 Urgent', normal: '🟡 Normal', relaxed: '🟢 Relaxed' };
-    const categoryLabels = { school: '🎓 Școală', personal: '👤 Personal', project: '💼 Proiect' };
-list.innerHTML = filtered.map(t => {
-        const overdue = t.deadline && t.deadline < today && !t.completed;
-        return `
-        <div class="task-item ${t.completed ? 'completed' : ''} ${overdue ? 'overdue' : ''}" data-priority="${t.priority}" data-id="${t.id}">
-            <div class="task-info">
-                <input type="checkbox" ${t.completed ? 'checked' : ''} onchange="toggleTask(${t.id})" />
-                <span class="task-text">${overdue ? '⚠️ ' : ''}${t.text}</span>
-            </div>
-            <div class="task-meta">
-                ${t.deadline ? <span class="task-badge">📅 ${t.deadline}</span> : ''}
-                ${t.deadline && !t.completed ? <span class="task-badge urgency ${t.deadline < today ? 'u-over' : ''}">${urgencyLabel(t)}</span> : ''}
-                <span class="task-badge">${categoryLabels[t.category]}</span>
-                <span class="task-badge">${priorityLabels[t.priority]}</span>
-                <button class="delete-btn" onclick="deleteTask(${t.id})">🗑️</button>
-            </div>
-        </div>
-    `;
-    }).join('');
-
-    requestAnimationFrame(() => {
-        list.querySelectorAll('.task-item').forEach(el => el.classList.add('show'));
-    });
-}
-
-
-function deleteTask(id) {
-    if (!confirm('Ești sigur că vrei să ștergi acest task?')) return;
-    const el = document.querySelector(`.task-item[data-id="${id}"]`);
-    if (el) el.classList.add('removing');
-    setTimeout(() => {
-        tasks = tasks.filter(t => t.id !== id);
-        saveTasks();
-        renderTasks(document.getElementById('filter-category').value);
-        updateStats();
-    }, 350);
 }

--- a/style.css
+++ b/style.css
@@ -28,6 +28,10 @@
     box-sizing: border-box;
 }
 
+html {
+    scroll-behavior: smooth;
+}
+
 body {
     font-family: 'Space Grotesk', sans-serif;
     background: var(--bg);
@@ -89,7 +93,7 @@ body {
 
 /* ===== MAIN ===== */
 main {
-    max-width: 800px;
+    max-width: 1000px;
     margin: 2rem auto;
     padding: 0 1rem;
     display: flex;
@@ -103,6 +107,7 @@ section {
     border-radius: 12px;
     padding: 1.5rem;
     box-shadow: var(--shadow);
+    scroll-margin-top: 5rem;
 }
 
 section h2 {
@@ -144,67 +149,111 @@ section h2 {
 
 /* ===== TASK FORM ===== */
 .form-container {
+    display: grid;
+    grid-template-columns: 2fr 1fr 1fr 1fr;
+    gap: 0.6rem;
+    align-items: center;
+}
+
+#add-task-btn {
+    grid-column: 1 / -1;
+    justify-self: center;
+    padding: 0.55rem 2rem;
+}
+
+#deadline-toggle {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    color: var(--text);
+    padding: 0.65rem 0.9rem;
+    border-radius: 8px;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 0.95rem;
+    width: 100%;
+    text-align: center;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+#deadline-toggle:hover {
+    border-color: var(--primary);
+}
+
+#deadline-display {
+    color: var(--text-secondary);
+    font-weight: 600;
+}
+
+.deadline-panel {
+    grid-column: 1 / -1;
+    display: none;
+    padding: 0.8rem;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    flex-direction: column;
+    gap: 0.6rem;
+}
+
+.deadline-panel.open {
     display: flex;
+}
+
+.quick-deadlines {
+    display: flex;
+    gap: 0.5rem;
     flex-wrap: wrap;
-    gap: 0.8rem;
+}
+
+.quick-deadlines button {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    color: var(--text-secondary);
+    padding: 0.35rem 0.8rem;
+    border-radius: 16px;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 0.8rem;
+    transition: background 0.2s, color 0.2s, border-color 0.2s;
+}
+
+.quick-deadlines button:hover,
+.quick-deadlines button.active {
+    background: var(--primary);
+    color: white;
+    border-color: var(--primary);
 }
 
 .form-container input,
 .form-container select {
-    padding: 0.6rem 1rem;
+    padding: 0.65rem 0.9rem;
     border: 1px solid var(--border);
     border-radius: 8px;
     background: var(--bg);
     color: var(--text);
     font-family: inherit;
     font-size: 0.95rem;
-    flex: 1;
-    min-width: 150px;
+    width: 100%;
+    min-width: 0;
 }
 
 #add-task-btn {
     background: var(--primary);
     color: white;
     border: none;
-    padding: 0.6rem 1.5rem;
+    padding: 0.65rem 1.4rem;
     border-radius: 8px;
     cursor: pointer;
     font-weight: 600;
     font-size: 0.95rem;
     transition: background 0.2s;
+    white-space: nowrap;
 }
 
 #add-task-btn:hover {
     background: var(--primary-hover);
-}
-
-/* ===== STATS ===== */
-.stats-container {
-    display: flex;
-    gap: 1rem;
-    justify-content: center;
-}
-
-.stat-card {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    background: var(--bg);
-    border-radius: 10px;
-    padding: 1rem 2rem;
-    flex: 1;
-}
-
-.stat-number {
-    font-size: 2rem;
-    font-weight: 700;
-    color: var(--primary);
-}
-
-.stat-label {
-    font-size: 0.85rem;
-    color: var(--text-secondary);
-    margin-top: 0.3rem;
 }
 
 /* ===== TASK LIST ===== */
@@ -212,7 +261,47 @@ section h2 {
     display: flex;
     justify-content: space-between;
     align-items: center;
+    gap: 0.6rem;
+    flex-wrap: wrap;
     margin-bottom: 1rem;
+}
+
+.task-list-header h2 {
+    flex: 1;
+    min-width: 180px;
+}
+
+#clear-completed-btn {
+    background: transparent;
+    border: 1px solid var(--border);
+    color: var(--text-secondary);
+    padding: 0.4rem 0.8rem;
+    border-radius: 8px;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 0.85rem;
+    transition: background 0.2s, color 0.2s;
+}
+
+#clear-completed-btn:hover {
+    background: #fee2e2;
+    color: #991b1b;
+    border-color: #fee2e2;
+}
+
+#sort-tasks {
+    padding: 0.4rem 0.8rem;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--bg);
+    color: var(--text);
+    font-family: inherit;
+    font-size: 0.9rem;
+    cursor: pointer;
+}
+
+.task-list-header h2 {
+    margin-bottom: 0;
 }
 
 #filter-category {
@@ -237,7 +326,7 @@ section h2 {
     border-left: 4px solid var(--primary);
     opacity: 0;
     transform: translateY(-6px);
-    transition: opacity 0.35s ease, transform 0.35s ease;
+    transition: opacity 0.35s ease, transform 0.35s ease, border-color 0.2s;
 }
 
 .task-item.show {
@@ -249,13 +338,14 @@ section h2 {
     opacity: 0.5;
 }
 
-.task-item.completed .task-text {
-    text-decoration: line-through;
-}
-
 .task-item.removing {
     opacity: 0 !important;
     transform: translateX(20px);
+}
+
+.task-item.overdue {
+    border: 2px solid #ef4444;
+    border-left-width: 4px;
 }
 
 .task-item[data-priority="urgent"] {
@@ -268,6 +358,10 @@ section h2 {
 
 .task-item[data-priority="relaxed"] {
     border-left-color: #22c55e;
+}
+
+.task-item.completed .task-text {
+    text-decoration: line-through;
 }
 
 .task-info {
@@ -291,7 +385,9 @@ section h2 {
 .task-meta {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.4rem;
+    flex-wrap: wrap;
+    justify-content: flex-end;
 }
 
 .task-badge {
@@ -303,15 +399,29 @@ section h2 {
     white-space: nowrap;
 }
 
+.task-badge.urgency {
+    background: #fef3c7;
+    color: #92400e;
+    font-weight: 600;
+}
+
+.task-badge.urgency.u-over {
+    background: #fee2e2;
+    color: #991b1b;
+}
+
+.edit-btn,
 .delete-btn {
     background: none;
     border: none;
     cursor: pointer;
     font-size: 1rem;
+    padding: 0.2rem;
     opacity: 0.5;
     transition: opacity 0.2s;
 }
 
+.edit-btn:hover,
 .delete-btn:hover {
     opacity: 1;
 }
@@ -321,6 +431,35 @@ section h2 {
     color: var(--text-secondary);
     padding: 2rem 0;
     font-style: italic;
+}
+
+/* ===== STATS ===== */
+.stats-container {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1rem;
+}
+
+.stat-card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    background: var(--bg);
+    border-radius: 10px;
+    padding: 1rem 2rem;
+    flex: 1;
+}
+
+.stat-number {
+    font-size: 2rem;
+    font-weight: 700;
+    color: var(--primary);
+}
+
+.stat-label {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    margin-top: 0.3rem;
 }
 
 /* ===== PROGRESS BAR ===== */
@@ -352,42 +491,43 @@ section h2 {
     color: var(--text-secondary);
 }
 
-.task-item.overdue {
-    border: 2px solid #ef4444;
-    border-left-width: 4px;
-}
-
-.task-badge.urgency {
-    background: #fef3c7;
-    color: #92400e;
-    font-weight: 600;
-}
-
-.task-badge.urgency.u-over {
-    background: #fee2e2;
-    color: #991b1b;
-}
-
-#sort-tasks {
-    padding: 0.4rem 0.8rem;
-    border: 1px solid var(--border);
-    border-radius: 8px;
-    background: var(--bg);
-    color: var(--text);
-    font-family: inherit;
-    font-size: 0.9rem;
-    cursor: pointer;
-}
-
-.task-list-header {
-    gap: 0.6rem;
-    flex-wrap: wrap;
-}
-
 /* ===== FOOTER ===== */
 #footer {
     text-align: center;
     padding: 1.5rem;
     color: var(--text-secondary);
     font-size: 0.9rem;
+}
+
+/* ===== RESPONSIVE ===== */
+@media (max-width: 600px) {
+    #header {
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        padding: 1rem;
+    }
+
+    .header-nav {
+        order: 3;
+        width: 100%;
+        justify-content: center;
+    }
+
+    .form-container {
+        grid-template-columns: 1fr;
+    }
+
+    .task-item {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.5rem;
+    }
+
+    .task-meta {
+        align-self: flex-end;
+    }
+
+    .stats-container {
+        grid-template-columns: 1fr;
+    }
 }


### PR DESCRIPTION
Replaces the bare date input with a collapsible deadline panel (quick options + manual picker, two-way synced). Adds a "Clear completed" bulk delete button, polishes the form layout to a 4-column grid with the Add button centered below, widens main to 1000px and removes the header nav links.

Closes #32 
