### PR TITLE
Fix: fetchQuote() uses API Ninjas to bypass CORS

### DIFF
--- a/script.js
+++ b/script.js
@@ -188,10 +188,12 @@ window.onload = function () {
 // ===== FETCH QUOTE =====
 async function fetchQuote() {
     try {
-        const response = await fetch('https://zenquotes.io/api/random');
+        const response = await fetch('https://api.api-ninjas.com/v1/quotes', {
+            headers: { 'X-Api-Key': 'cWVShiG81EBKoTg8zxXli1bKdMileuhfBWKuV4Z6' }
+        });
         const data = await response.json();
-        document.getElementById('quote-text').textContent = data[0].q;
-        document.getElementById('quote-author').textContent = '— ' + data[0].a;
+        document.getElementById('quote-text').textContent = data[0].quote;
+        document.getElementById('quote-author').textContent = '— ' + data[0].author;
     } catch (error) {
         document.getElementById('quote-text').textContent = 'Stay focused and keep going!';
         document.getElementById('quote-author').textContent = '— To-Do Planner';


### PR DESCRIPTION
The "New Quote" button was not working due to CORS restrictions 
on the ZenQuotes API. Switched to API Ninjas which supports 
browser requests directly.

Changes:
- Updated fetchQuote() to use API Ninjas /v1/quotes endpoint
- Added API key authentication header

Closes  #34 